### PR TITLE
Updates round advancement logic

### DIFF
--- a/client/src/components/tournament/LiveTournament.jsx
+++ b/client/src/components/tournament/LiveTournament.jsx
@@ -19,7 +19,9 @@ import GameCard from './GameCard'
 import RoundTimer from './RoundTimer'
 import PlayerSwapDialog from './PlayerSwapDialog'
 
-export default function LiveTournament({ tournament, currentRound, isAdmin, isScorer }) {
+import { getCurrentRound, isTournamentComplete } from '@/utils/tournament'
+
+export default function LiveTournament({ tournament, isAdmin, isScorer }) {
   const { toast } = useToast()
   const tournamentStore = useTournamentStore()
   const [timerDuration, setTimerDuration] = useState(tournament.settings.timer?.duration || 30)
@@ -27,6 +29,18 @@ export default function LiveTournament({ tournament, currentRound, isAdmin, isSc
   const [swapContext, setSwapContext] = useState(null)
   const [showRoundCompleteDialog, setShowRoundCompleteDialog] = useState(false)
   const [userDeclinedCompletion, setUserDeclinedCompletion] = useState(false)
+  
+  // Calculate current round reactively
+  const currentRound = getCurrentRound(tournament)
+  
+  // Close round complete dialog when current round changes (admin confirmed advancement)
+  useEffect(() => {
+    if (showRoundCompleteDialog) {
+      // If tournament completed or round advanced, close the dialog
+      setShowRoundCompleteDialog(false)
+      setUserDeclinedCompletion(false)
+    }
+  }, [currentRound, tournament.currentState?.status])
   
   const round = tournament.schedule?.find(r => r.round === currentRound)
   const hasSchedule = tournament.schedule && tournament.schedule.length > 0
@@ -63,7 +77,7 @@ export default function LiveTournament({ tournament, currentRound, isAdmin, isSc
           : 'Tournament Complete!'
       })
       
-      setShowRoundCompleteDialog(false)
+      // Don't manually close dialog - useEffect will handle it when currentRound changes
     } catch (error) {
       toast({
         title: 'Error',

--- a/client/src/components/tournament/TournamentView.jsx
+++ b/client/src/components/tournament/TournamentView.jsx
@@ -152,12 +152,6 @@ export default function TournamentView({ tournamentId }) {
         // Update tournament data
         tournamentStore.setTournament(data.tournament)
         
-        // For viewers, this just indicates a round has all games scored
-        // They won't advance until admin confirms via round-advanced event
-        if (!isAdmin) {
-          console.log(`Round ${data.completedRound} scoring completed - waiting for admin confirmation`)
-        }
-        
         toast({
           title: 'Round Scoring Complete!',
           description: `All games in Round ${data.completedRound} have been scored`
@@ -167,11 +161,12 @@ export default function TournamentView({ tournamentId }) {
         // Update tournament data with new current round
         tournamentStore.setTournament(data.tournament)
         
-        // For viewers, automatically move to the live tab to see new round
+        // For viewers, automatically navigate to the appropriate view
         if (!isAdmin && !manualTabChangeRef.current) {
           if (data.tournamentCompleted) {
             setActiveTab('completion')
           } else if (data.newCurrentRound) {
+            // Always ensure viewers are on live tab for new round, even if already there
             setActiveTab('live')
           }
         }
@@ -650,7 +645,6 @@ export default function TournamentView({ tournamentId }) {
             <TabsContent value="live">
               <LiveTournament 
                 tournament={tournament} 
-                currentRound={currentRound}
                 isAdmin={isAdmin}
                 isScorer={isScorer}
               />


### PR DESCRIPTION
Improves the user experience during round advancements by automatically navigating viewers to the appropriate tab (live or completion).

Removes redundant `currentRound` prop from `LiveTournament` and instead calculates it reactively. This ensures the component always displays the correct round information.

Closes the round completion dialog automatically when the admin confirms advancement, preventing potential UI inconsistencies.